### PR TITLE
personalized mode bug fix. (mode share per user)

### DIFF
--- a/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
+++ b/zeppelin-server/src/main/java/org/apache/zeppelin/socket/NotebookServer.java
@@ -780,7 +780,7 @@ public class NotebookServer extends WebSocketServlet implements
 
     NotebookAuthorization notebookAuthorization = notebook.getNotebookAuthorization();
     if (!notebookAuthorization.isOwner(noteId, userAndRoles)) {
-      permissionError(conn, "rename", fromMessage.principal,
+      permissionError(conn, "persoanlized ", fromMessage.principal,
           userAndRoles, notebookAuthorization.getOwners(noteId));
       return;
     }
@@ -790,7 +790,7 @@ public class NotebookServer extends WebSocketServlet implements
       note.setPersonalizedMode(isPersonalized);
       AuthenticationInfo subject = new AuthenticationInfo(fromMessage.principal);
       note.persist(subject);
-      sendNote(conn, userAndRoles, notebook, fromMessage);
+      broadcastNote(note);
     }
   }
 

--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -927,6 +927,8 @@
 
       if ($scope.note === null) {
         $scope.note = note;
+      } else {
+        $scope.note.config.personalizedMode = note.config.personalizedMode;
       }
       initializeLookAndFeel();
       //open interpreter binding setting when there're none selected


### PR DESCRIPTION
![123123ppp](https://cloud.githubusercontent.com/assets/10525473/21213045/44013a82-c2d5-11e6-82e6-5c7591069516.gif)

support `live mode share `
the notes about using the user-to-user mode are reflected in real time.
corrected invalid log name.
only `owner` can modify personalized mode.