### PR TITLE
change mode name shared to collaboration and dialog message

### DIFF
--- a/zeppelin-web/src/app/notebook/notebook-actionBar.html
+++ b/zeppelin-web/src/app/notebook/notebook-actionBar.html
@@ -80,7 +80,7 @@ limitations under the License.
               ng-if="ticket.principal && ticket.principal !== 'anonymous'"
               ng-hide="viewOnly || note.config.personalizedMode === 'true'"
               ng-click="toggleNotePersonalizedMode()"
-              tooltip-placement="bottom" tooltip="Shared mode {{isOwner ? '' : '(owner can change)'}}">
+              tooltip-placement="bottom" tooltip="Collaboration mode {{isOwner ? '' : '(owner can change)'}}">
         <i class="fa fa-users"></i>
       </button>
     </span>

--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -769,7 +769,10 @@
         BootstrapDialog.confirm({
           closable: true,
           title: 'Setting the result display',
-          message: 'Do you want to personalize your analysis??',
+          message: function(dialog) {
+            var modeText = $scope.note.config.personalizedMode === 'true' ? 'Collaboration' : 'Personalize';
+            return 'Do you want to <span class="text-info">' + modeText + '</span> your analysis?';
+          },
           callback: function(result) {
             if (result) {
               if ($scope.note.config.personalizedMode === undefined) {

--- a/zeppelin-web/src/app/notebook/notebook.controller.js
+++ b/zeppelin-web/src/app/notebook/notebook.controller.js
@@ -770,7 +770,7 @@
           closable: true,
           title: 'Setting the result display',
           message: function(dialog) {
-            var modeText = $scope.note.config.personalizedMode === 'true' ? 'Collaboration' : 'Personalize';
+            var modeText = $scope.note.config.personalizedMode === 'true' ? 'collaborate' : 'personalize';
             return 'Do you want to <span class="text-info">' + modeText + '</span> your analysis?';
           },
           callback: function(result) {


### PR DESCRIPTION
## tooltip 
(moon's order)
mode name : `shared mode` -> `collaboration mode`
![03](https://cloud.githubusercontent.com/assets/10525473/21304546/409a65e4-c609-11e6-91e8-5889beef5aa9.png)

## dialog text
![01](https://cloud.githubusercontent.com/assets/10525473/21304548/43c76df2-c609-11e6-8feb-55dfed400bf4.png)
![02](https://cloud.githubusercontent.com/assets/10525473/21304549/43ebc670-c609-11e6-8ec5-2710f0bf3601.png)

